### PR TITLE
Use stepClassName to find .active steps

### DIFF
--- a/lib/jquery.easyWizard.js
+++ b/lib/jquery.easyWizard.js
@@ -122,7 +122,7 @@
 		},
 		prevStep : function( ) {
 			thisSettings = arrSettings[this.index()];
-			$activeStep = this.find('.active');
+			$activeStep = this.find('.'+ thisSettings.stepClassName +'.active');
 			if($activeStep.prev('.'+thisSettings.stepClassName).length) {
 				prevStep = parseInt($activeStep.attr('data-step')) - 1;
 				easyWizardMethods.goToStep.call(this, prevStep);
@@ -130,7 +130,7 @@
 		},
 		nextStep : function( ) {
 			thisSettings = arrSettings[this.index()];
-			$activeStep = this.find('.active');
+			$activeStep = this.find('.'+ thisSettings.stepClassName +'.active');
 			if($activeStep.next('.'+thisSettings.stepClassName).length) {
 				nextStep = parseInt($activeStep.attr('data-step')) + 1;
 				easyWizardMethods.goToStep.call(this, nextStep);
@@ -139,7 +139,7 @@
 		goToStep : function(step) {
 			thisSettings = arrSettings[this.index()];
 
-			$activeStep = this.find('.active');
+			$activeStep = this.find('.'+ thisSettings.stepClassName +'.active');
 			$nextStep = this.find('.'+thisSettings.stepClassName+'[data-step="'+step+'"]');
 			currentStep = $activeStep.attr('data-step');
 


### PR DESCRIPTION
Use `.step.active` in order to find the active step, otherwise the `active` class is removed from child elements in the step (which interferes with bootstrap carousels for instance).
