### PR TITLE
Use next() and prev() instead of +/- 1

### DIFF
--- a/lib/jquery.easyWizard.js
+++ b/lib/jquery.easyWizard.js
@@ -130,7 +130,7 @@
             thisSettings = arrSettings[this.index()];
             $activeStep = this.find('.'+ thisSettings.stepClassName +'.active');
             if($activeStep.prev('.'+thisSettings.stepClassName).length) {               
-                prevStep = parseInt($activeStep.attr('data-step')) - 1;
+                prevStep = parseInt($activeStep.prev().attr('data-step'));
                 easyWizardMethods.goToStep.call(this, prevStep);
             }
         },
@@ -138,7 +138,7 @@
             thisSettings = arrSettings[this.index()];           
             $activeStep = this.find('.'+ thisSettings.stepClassName +'.active');
             if($activeStep.next('.'+thisSettings.stepClassName).length) {
-                nextStep = parseInt($activeStep.attr('data-step')) + 1;
+                nextStep = parseInt($activeStep.next().attr('data-step'));
                 easyWizardMethods.goToStep.call(this, nextStep);
             }
         },


### PR DESCRIPTION
When dynamically removing a step, the scripts breaks. The PR makes it possible to remove a step from the form.
