### PR TITLE
fix a typo in bower.json and bump version so bower knows

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,7 @@
 {
   "name": "jquery.easyWizard",
-  "version": "1.1.2",
-  "main": ".lib/jquery.easyWizard.js",
+  "version": "1.1.3",
+  "main": "lib/jquery.easyWizard.js",
   "dependencies": {
     "jquery": ">=1.8"
   },


### PR DESCRIPTION
The . in the lib uri doesn't actually exist and made it impossible for automation to find the package.

**Please make sure the tags are added if they don't carry over with the pull request**